### PR TITLE
feat(google): use iosClientConfig from AppConfig

### DIFF
--- a/Sources/Rownd/Models/Context/AppConfig.swift
+++ b/Sources/Rownd/Models/Context/AppConfig.swift
@@ -93,13 +93,15 @@ extension SignInMethods: Codable {
 
 public struct GoogleSignInMethodConfig: Hashable {
     public var enabled: Bool?
-    public var clientId: String?
+    public var serverClientId: String?
+    public var iosClientId: String?
 }
 
 extension GoogleSignInMethodConfig: Codable {
     enum CodingKeys: String, CodingKey {
         case enabled
-        case clientId = "client_id"
+        case serverClientId = "client_id"
+        case iosClientId = "ios_client_id"
     }
 }
 

--- a/Sources/Rownd/Models/RowndConfig.swift
+++ b/Sources/Rownd/Models/RowndConfig.swift
@@ -15,7 +15,6 @@ public struct RowndConfig: Encodable {
     public var appKey = ""
     public var forceDarkMode = false
     public var postSignInRedirect: String? = nil
-    public var googleClientId: String = ""
     public var customizations: RowndCustomizations = RowndCustomizations()
     
     func toJson() -> String {

--- a/Sources/Rownd/Rownd.swift
+++ b/Sources/Rownd/Rownd.swift
@@ -112,13 +112,15 @@ public class Rownd: NSObject {
             if (googleConfig == nil || googleConfig?.enabled == false) {
                 return logger.error("Sign in with Google is not enabled. Turn it on in the Rownd platform")
             }
-            if (googleConfig?.clientId == nil || googleConfig?.clientId == "" || config.googleClientId == "") {
-                let clientId = googleConfig?.clientId
+            if (googleConfig?.serverClientId == nil ||
+                googleConfig?.serverClientId == "" ||
+                googleConfig?.iosClientId == nil ||
+                googleConfig?.iosClientId == "") {
                 return logger.error("Cannot sign in with Google. Missing client configuration")
             }
             let gidConfig = GIDConfiguration(
-                clientID: config.googleClientId,   // (IOS)
-                serverClientID: googleConfig?.clientId  // (Web)
+                clientID: (googleConfig?.iosClientId)!,   // (IOS)
+                serverClientID: googleConfig?.serverClientId  // (Web)
             )
 
             GIDSignIn.sharedInstance.signIn(


### PR DESCRIPTION
Pull the IOS client ID from the Rownd app config. Use this instead of the native Rownd config for Google Sign-in