### PR TITLE
feat(auth): prevent sign-outs during poor network conditions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -78,6 +78,16 @@ let package = Package(
             name: "Lottie",
             url: "https://github.com/airbnb/lottie-ios",
             .upToNextMajor(from: "3.4.3")
+        ),
+        .package(
+            name: "Factory",
+            url: "https://github.com/hmlongco/Factory",
+            .upToNextMajor(from: "1.2.8")
+        ),
+        .package(
+            name: "Mocker",
+            url: "https://github.com/WeTransfer/Mocker",
+            .upToNextMajor(from: "3.0.1")
         )
     ],
     
@@ -95,10 +105,17 @@ let package = Package(
                 "CodeScanner_Rownd",
                 "Get",
                 "GoogleSignIn",
-                "Lottie"
+                "Lottie",
+                "Factory"
             ],
             resources: [
                 .process("Resources/")
+            ]
+        ),
+        .testTarget(
+            name: "RowndTests",
+            dependencies: [
+                "Mocker"
             ]
         )
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -109,7 +109,7 @@ let package = Package(
                 "Factory"
             ],
             resources: [
-                .process("Resources/")
+                .process("Resources")
             ]
         ),
         .testTarget(

--- a/Rownd.podspec
+++ b/Rownd.podspec
@@ -30,6 +30,7 @@ Pod::Spec.new do |s|
   s.dependency 'Get', '~> 2.0.1'
   s.dependency 'GoogleSignIn', '~> 6.2.4'
   s.dependency 'lottie-ios', '~> 3.4.3'
+  s.dependency 'Factory', '~> 1.2.8'
 
   s.requires_arc     = true
   s.source_files     = 'Sources/**/*'

--- a/RowndFramework.xcodeproj/project.pbxproj
+++ b/RowndFramework.xcodeproj/project.pbxproj
@@ -35,10 +35,10 @@
 		B349906628CFCED9004ADF3F /* Customizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = B349906528CFCED9004ADF3F /* Customizations.swift */; };
 		B35E1ED12874C9C9007E989F /* HubViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35E1ED02874C9C9007E989F /* HubViewController.swift */; };
 		B36AA90B291D7273002B3B60 /* Mocker in Frameworks */ = {isa = PBXBuildFile; productRef = B36AA90A291D7273002B3B60 /* Mocker */; };
-		B36AA90E291D7296002B3B60 /* Shock in Frameworks */ = {isa = PBXBuildFile; productRef = B36AA90D291D7296002B3B60 /* Shock */; };
 		B36AA911291D9C52002B3B60 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36AA910291D9C52002B3B60 /* Helpers.swift */; };
 		B36AA914291DF829002B3B60 /* Factory in Frameworks */ = {isa = PBXBuildFile; productRef = B36AA913291DF829002B3B60 /* Factory */; };
 		B36AA917291DF8F7002B3B60 /* Container.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36AA915291DF8F1002B3B60 /* Container.swift */; };
+		B36AA91C291EFB2F002B3B60 /* NoInternet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36AA91B291EFB2F002B3B60 /* NoInternet.swift */; };
 		B36D430D28B4077F0038CF16 /* MagicLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36D430C28B4077F0038CF16 /* MagicLink.swift */; };
 		B36D430F28B5CCD20038CF16 /* KeyTransferProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36D430E28B5CCD20038CF16 /* KeyTransferProgress.swift */; };
 		B374E55C28545A1C00955719 /* framework.h in Headers */ = {isa = PBXBuildFile; fileRef = B374E55B28545A1C00955719 /* framework.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -118,6 +118,7 @@
 		B36AA90F291D753C002B3B60 /* RowndFrameworkTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RowndFrameworkTestApp.entitlements; sourceTree = "<group>"; };
 		B36AA910291D9C52002B3B60 /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		B36AA915291DF8F1002B3B60 /* Container.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Container.swift; sourceTree = "<group>"; };
+		B36AA91B291EFB2F002B3B60 /* NoInternet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoInternet.swift; sourceTree = "<group>"; };
 		B36D430C28B4077F0038CF16 /* MagicLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagicLink.swift; sourceTree = "<group>"; };
 		B36D430E28B5CCD20038CF16 /* KeyTransferProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyTransferProgress.swift; sourceTree = "<group>"; };
 		B374E55828545A1C00955719 /* Rownd.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rownd.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -177,7 +178,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B36AA90E291D7296002B3B60 /* Shock in Frameworks */,
 				B38A40AB2882020900FD0813 /* Rownd.framework in Frameworks */,
 				B36AA90B291D7273002B3B60 /* Mocker in Frameworks */,
 			);
@@ -262,6 +262,14 @@
 			path = Rownd;
 			sourceTree = "<group>";
 		};
+		B36AA91A291EFB2F002B3B60 /* Html */ = {
+			isa = PBXGroup;
+			children = (
+				B36AA91B291EFB2F002B3B60 /* NoInternet.swift */,
+			);
+			path = Html;
+			sourceTree = "<group>";
+		};
 		B374E54E28545A1C00955719 = {
 			isa = PBXGroup;
 			children = (
@@ -311,6 +319,7 @@
 		B374E56228545A2900955719 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				B36AA91A291EFB2F002B3B60 /* Html */,
 				B3F01B0128A8A53000EE764B /* KeyTransfer */,
 				B38A4095287FC0DC00FD0813 /* HubWebView */,
 				B35E1ED02874C9C9007E989F /* HubViewController.swift */,
@@ -456,7 +465,6 @@
 			name = RowndTests;
 			packageProductDependencies = (
 				B36AA90A291D7273002B3B60 /* Mocker */,
-				B36AA90D291D7296002B3B60 /* Shock */,
 			);
 			productName = RowndTests;
 			productReference = B38A40A72882020800FD0813 /* RowndTests.xctest */;
@@ -486,6 +494,9 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
+				KnownAssetTags = (
+					New,
+				);
 				LastSwiftUpdateCheck = 1340;
 				LastUpgradeCheck = 1340;
 				TargetAttributes = {
@@ -525,7 +536,6 @@
 				B30FBD8D28E780BF00216034 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				B30FBD9228E7811D00216034 /* XCRemoteSwiftPackageReference "CodeScanner_Rownd" */,
 				B36AA909291D7273002B3B60 /* XCRemoteSwiftPackageReference "Mocker" */,
-				B36AA90C291D7296002B3B60 /* XCRemoteSwiftPackageReference "Shock" */,
 				B36AA912291DF829002B3B60 /* XCRemoteSwiftPackageReference "Factory" */,
 			);
 			productRefGroup = B374E55928545A1C00955719 /* Products */;
@@ -593,6 +603,7 @@
 				B3F01B0328A8A60800EE764B /* KeyTransferViewController.swift in Sources */,
 				B38A409E288111F200FD0813 /* BottomSheetController.swift in Sources */,
 				B302E2D1286A4530005FD927 /* Exporter.swift in Sources */,
+				B36AA91C291EFB2F002B3B60 /* NoInternet.swift in Sources */,
 				B38A4087287E720E00FD0813 /* Constants.swift in Sources */,
 				B36D430D28B4077F0038CF16 /* MagicLink.swift in Sources */,
 				B302E2C928650C1D005FD927 /* APIClient.swift in Sources */,
@@ -1026,14 +1037,6 @@
 				minimumVersion = 3.0.0;
 			};
 		};
-		B36AA90C291D7296002B3B60 /* XCRemoteSwiftPackageReference "Shock" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/justeat/Shock";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 6.0.0;
-			};
-		};
 		B36AA912291DF829002B3B60 /* XCRemoteSwiftPackageReference "Factory" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/hmlongco/Factory";
@@ -1135,11 +1138,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B36AA909291D7273002B3B60 /* XCRemoteSwiftPackageReference "Mocker" */;
 			productName = Mocker;
-		};
-		B36AA90D291D7296002B3B60 /* Shock */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B36AA90C291D7296002B3B60 /* XCRemoteSwiftPackageReference "Shock" */;
-			productName = Shock;
 		};
 		B36AA913291DF829002B3B60 /* Factory */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/RowndFramework.xcodeproj/project.pbxproj
+++ b/RowndFramework.xcodeproj/project.pbxproj
@@ -26,7 +26,6 @@
 		B30FBD9428E7811D00216034 /* CodeScanner_Rownd in Frameworks */ = {isa = PBXBuildFile; productRef = B30FBD9328E7811D00216034 /* CodeScanner_Rownd */; };
 		B34490FE28DB9EEC00A992E9 /* AuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34490FD28DB9EEC00A992E9 /* AuthTests.swift */; };
 		B344910228DBA36200A992E9 /* MockedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B344910128DBA36200A992E9 /* MockedData.swift */; };
-		B344910528DBA42B00A992E9 /* Mocker in Frameworks */ = {isa = PBXBuildFile; productRef = B344910428DBA42B00A992E9 /* Mocker */; };
 		B344910928DBA72600A992E9 /* auth_refresh_response.json in Resources */ = {isa = PBXBuildFile; fileRef = B344910828DBA49E00A992E9 /* auth_refresh_response.json */; };
 		B344910A28DBA93800A992E9 /* auth_refresh_response.json in Resources */ = {isa = PBXBuildFile; fileRef = B344910828DBA49E00A992E9 /* auth_refresh_response.json */; };
 		B347C24F2877DAB600935115 /* Encryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = B347C24E2877DAB600935115 /* Encryption.swift */; };
@@ -35,6 +34,11 @@
 		B347C27B287CB46A00935115 /* JWTDecode in Frameworks */ = {isa = PBXBuildFile; productRef = B347C27A287CB46A00935115 /* JWTDecode */; };
 		B349906628CFCED9004ADF3F /* Customizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = B349906528CFCED9004ADF3F /* Customizations.swift */; };
 		B35E1ED12874C9C9007E989F /* HubViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35E1ED02874C9C9007E989F /* HubViewController.swift */; };
+		B36AA90B291D7273002B3B60 /* Mocker in Frameworks */ = {isa = PBXBuildFile; productRef = B36AA90A291D7273002B3B60 /* Mocker */; };
+		B36AA90E291D7296002B3B60 /* Shock in Frameworks */ = {isa = PBXBuildFile; productRef = B36AA90D291D7296002B3B60 /* Shock */; };
+		B36AA911291D9C52002B3B60 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36AA910291D9C52002B3B60 /* Helpers.swift */; };
+		B36AA914291DF829002B3B60 /* Factory in Frameworks */ = {isa = PBXBuildFile; productRef = B36AA913291DF829002B3B60 /* Factory */; };
+		B36AA917291DF8F7002B3B60 /* Container.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36AA915291DF8F1002B3B60 /* Container.swift */; };
 		B36D430D28B4077F0038CF16 /* MagicLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36D430C28B4077F0038CF16 /* MagicLink.swift */; };
 		B36D430F28B5CCD20038CF16 /* KeyTransferProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36D430E28B5CCD20038CF16 /* KeyTransferProgress.swift */; };
 		B374E55C28545A1C00955719 /* framework.h in Headers */ = {isa = PBXBuildFile; fileRef = B374E55B28545A1C00955719 /* framework.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -111,6 +115,9 @@
 		B347C27428792AD900935115 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		B349906528CFCED9004ADF3F /* Customizations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customizations.swift; sourceTree = "<group>"; };
 		B35E1ED02874C9C9007E989F /* HubViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubViewController.swift; sourceTree = "<group>"; };
+		B36AA90F291D753C002B3B60 /* RowndFrameworkTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RowndFrameworkTestApp.entitlements; sourceTree = "<group>"; };
+		B36AA910291D9C52002B3B60 /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
+		B36AA915291DF8F1002B3B60 /* Container.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Container.swift; sourceTree = "<group>"; };
 		B36D430C28B4077F0038CF16 /* MagicLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagicLink.swift; sourceTree = "<group>"; };
 		B36D430E28B5CCD20038CF16 /* KeyTransferProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyTransferProgress.swift; sourceTree = "<group>"; };
 		B374E55828545A1C00955719 /* Rownd.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rownd.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -158,6 +165,7 @@
 				C5ACD08E28E38D9B00A9F2D9 /* AnyCodable in Frameworks */,
 				B347C27B287CB46A00935115 /* JWTDecode in Frameworks */,
 				B302E2BB28641A7A005FD927 /* ReSwift in Frameworks */,
+				B36AA914291DF829002B3B60 /* Factory in Frameworks */,
 				B39ECA9728E242B10055CB60 /* Lottie in Frameworks */,
 				B38A40CC288274D900FD0813 /* SwiftKeychainWrapper in Frameworks */,
 				B38A40CF2883C81D00FD0813 /* Sodium in Frameworks */,
@@ -169,8 +177,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B36AA90E291D7296002B3B60 /* Shock in Frameworks */,
 				B38A40AB2882020900FD0813 /* Rownd.framework in Frameworks */,
-				B344910528DBA42B00A992E9 /* Mocker in Frameworks */,
+				B36AA90B291D7273002B3B60 /* Mocker in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -294,6 +303,7 @@
 				B3F01B0F28AB607B00EE764B /* SignInLinks.swift */,
 				B349906528CFCED9004ADF3F /* Customizations.swift */,
 				B39ECA9D28E2A2B50055CB60 /* LottieSwiftView.swift */,
+				B36AA915291DF8F1002B3B60 /* Container.swift */,
 			);
 			path = framework;
 			sourceTree = "<group>";
@@ -335,6 +345,7 @@
 				B38A40B12882024400FD0813 /* EncryptionTests.swift */,
 				B34490FD28DB9EEC00A992E9 /* AuthTests.swift */,
 				B344910128DBA36200A992E9 /* MockedData.swift */,
+				B36AA910291D9C52002B3B60 /* Helpers.swift */,
 			);
 			path = RowndTests;
 			sourceTree = "<group>";
@@ -342,6 +353,7 @@
 		B38A40B82882185800FD0813 /* RowndFrameworkTestApp */ = {
 			isa = PBXGroup;
 			children = (
+				B36AA90F291D753C002B3B60 /* RowndFrameworkTestApp.entitlements */,
 				B344910628DBA44B00A992E9 /* Resources */,
 				B38A40B92882185800FD0813 /* RowndFrameworkTestAppApp.swift */,
 				B38A40BB2882185800FD0813 /* ContentView.swift */,
@@ -421,6 +433,7 @@
 				B30FBD8E28E780BF00216034 /* GoogleSignIn */,
 				B30FBD9028E780BF00216034 /* GoogleSignInSwift */,
 				B30FBD9328E7811D00216034 /* CodeScanner_Rownd */,
+				B36AA913291DF829002B3B60 /* Factory */,
 			);
 			productName = framework;
 			productReference = B374E55828545A1C00955719 /* Rownd.framework */;
@@ -442,7 +455,8 @@
 			);
 			name = RowndTests;
 			packageProductDependencies = (
-				B344910428DBA42B00A992E9 /* Mocker */,
+				B36AA90A291D7273002B3B60 /* Mocker */,
+				B36AA90D291D7296002B3B60 /* Shock */,
 			);
 			productName = RowndTests;
 			productReference = B38A40A72882020800FD0813 /* RowndTests.xctest */;
@@ -506,11 +520,13 @@
 				B38A40CA288274D800FD0813 /* XCRemoteSwiftPackageReference "SwiftKeychainWrapper" */,
 				B38A40CD2883C81D00FD0813 /* XCRemoteSwiftPackageReference "swift-sodium" */,
 				B396004328D4348D00754238 /* XCRemoteSwiftPackageReference "get" */,
-				B344910328DBA42B00A992E9 /* XCRemoteSwiftPackageReference "Mocker" */,
 				C5ACD08728E389C500A9F2D9 /* XCRemoteSwiftPackageReference "AnyCodable" */,
 				B39ECA9528E242B10055CB60 /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				B30FBD8D28E780BF00216034 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				B30FBD9228E7811D00216034 /* XCRemoteSwiftPackageReference "CodeScanner_Rownd" */,
+				B36AA909291D7273002B3B60 /* XCRemoteSwiftPackageReference "Mocker" */,
+				B36AA90C291D7296002B3B60 /* XCRemoteSwiftPackageReference "Shock" */,
+				B36AA912291DF829002B3B60 /* XCRemoteSwiftPackageReference "Factory" */,
 			);
 			productRefGroup = B374E55928545A1C00955719 /* Products */;
 			projectDirPath = "";
@@ -562,6 +578,7 @@
 				B349906628CFCED9004ADF3F /* Customizations.swift in Sources */,
 				B38A4089287F28D000FD0813 /* AccountManagerView.swift in Sources */,
 				B38A4085287E16EE00FD0813 /* LoggingExcluded.swift in Sources */,
+				B36AA917291DF8F7002B3B60 /* Container.swift in Sources */,
 				B3F01B1228ABE9C400EE764B /* KeyScanner.swift in Sources */,
 				B302E2CD2866C75A005FD927 /* Auth.swift in Sources */,
 				B302E2C028641F41005FD927 /* AppConfig.swift in Sources */,
@@ -602,6 +619,7 @@
 				B344910228DBA36200A992E9 /* MockedData.swift in Sources */,
 				B38A40B22882024400FD0813 /* EncryptionTests.swift in Sources */,
 				B34490FE28DB9EEC00A992E9 /* AuthTests.swift in Sources */,
+				B36AA911291D9C52002B3B60 /* Helpers.swift in Sources */,
 				B38A40AA2882020900FD0813 /* RowndTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -820,7 +838,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 34CNMPW6U9;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.rownd.RowndTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -839,7 +857,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 34CNMPW6U9;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.rownd.RowndTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -855,6 +873,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = RowndFrameworkTestApp/RowndFrameworkTestApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"RowndFrameworkTestApp/Preview Content\"";
@@ -866,7 +885,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -874,6 +893,9 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.rownd.RowndFrameworkTestApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -885,6 +907,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = RowndFrameworkTestApp/RowndFrameworkTestApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"RowndFrameworkTestApp/Preview Content\"";
@@ -896,7 +919,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -904,6 +927,9 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.rownd.RowndFrameworkTestApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -984,20 +1010,36 @@
 				minimumVersion = 2.0.0;
 			};
 		};
-		B344910328DBA42B00A992E9 /* XCRemoteSwiftPackageReference "Mocker" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/WeTransfer/Mocker#activating-the-mocker";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
-			};
-		};
 		B347C279287CB46900935115 /* XCRemoteSwiftPackageReference "JWTDecode" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/auth0/JWTDecode.swift";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 2.0.0;
+			};
+		};
+		B36AA909291D7273002B3B60 /* XCRemoteSwiftPackageReference "Mocker" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "git@github.com:WeTransfer/Mocker.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.0.0;
+			};
+		};
+		B36AA90C291D7296002B3B60 /* XCRemoteSwiftPackageReference "Shock" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/justeat/Shock";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.0.0;
+			};
+		};
+		B36AA912291DF829002B3B60 /* XCRemoteSwiftPackageReference "Factory" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/hmlongco/Factory";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 		B38A409F2881157D00FD0813 /* XCRemoteSwiftPackageReference "LBBottomSheet" */ = {
@@ -1084,15 +1126,25 @@
 			package = B30FBD9228E7811D00216034 /* XCRemoteSwiftPackageReference "CodeScanner_Rownd" */;
 			productName = CodeScanner_Rownd;
 		};
-		B344910428DBA42B00A992E9 /* Mocker */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B344910328DBA42B00A992E9 /* XCRemoteSwiftPackageReference "Mocker" */;
-			productName = Mocker;
-		};
 		B347C27A287CB46A00935115 /* JWTDecode */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = B347C279287CB46900935115 /* XCRemoteSwiftPackageReference "JWTDecode" */;
 			productName = JWTDecode;
+		};
+		B36AA90A291D7273002B3B60 /* Mocker */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B36AA909291D7273002B3B60 /* XCRemoteSwiftPackageReference "Mocker" */;
+			productName = Mocker;
+		};
+		B36AA90D291D7296002B3B60 /* Shock */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B36AA90C291D7296002B3B60 /* XCRemoteSwiftPackageReference "Shock" */;
+			productName = Shock;
+		};
+		B36AA913291DF829002B3B60 /* Factory */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B36AA912291DF829002B3B60 /* XCRemoteSwiftPackageReference "Factory" */;
+			productName = Factory;
 		};
 		B38A40A02881157D00FD0813 /* LBBottomSheet */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/RowndFramework.xcodeproj/xcuserdata/mhamann.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/RowndFramework.xcodeproj/xcuserdata/mhamann.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -12,7 +12,7 @@
 		<key>RowndFrameworkTestApp.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/RowndFramework.xcodeproj/xcuserdata/mhamann.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/RowndFramework.xcodeproj/xcuserdata/mhamann.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>Rownd.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>30</integer>
 		</dict>
 		<key>RowndFrameworkTestApp.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>29</integer>
 		</dict>
 	</dict>
 </dict>

--- a/RowndFramework.xcodeproj/xcuserdata/mhamann.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/RowndFramework.xcodeproj/xcuserdata/mhamann.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>Rownd.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>30</integer>
+			<integer>0</integer>
 		</dict>
 		<key>RowndFrameworkTestApp.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>29</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/RowndFrameworkTestApp/RowndFrameworkTestApp.entitlements
+++ b/RowndFrameworkTestApp/RowndFrameworkTestApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/RowndTests/Helpers.swift
+++ b/RowndTests/Helpers.swift
@@ -1,0 +1,20 @@
+//
+//  Helpers.swift
+//  RowndTests
+//
+//  Created by Matt Hamann on 11/10/22.
+//
+
+import Foundation
+import Get
+import Mocker
+
+extension APIClient {
+    static func mock(_ configure: (inout APIClient.Configuration) -> Void = { _ in }) -> APIClient {
+        APIClient(baseURL: URL(string: "https://api.rownd.io")) {
+            $0.sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
+            $0.sessionConfiguration.urlCache = nil
+            configure(&$0)
+        }
+    }
+}

--- a/Sources/Rownd/Models/Context/Auth.swift
+++ b/Sources/Rownd/Models/Context/Auth.swift
@@ -67,12 +67,19 @@ extension AuthState: Codable {
         }
     }
     
-    func getAccessToken() async -> String? {
+    func getAccessToken() async throws -> String? {
         do {
             let authState = try await Rownd.authenticator.getValidToken()
             return authState.accessToken
         } catch {
             logger.warning("Failed to retrieve access token: \(String(describing: error))")
+
+            switch (error as? AuthenticationError) {
+            case .networkConnectionFailure:
+                throw error
+            default: break
+            }
+
             return nil
         }
     }

--- a/Sources/Rownd/Models/Context/User.swift
+++ b/Sources/Rownd/Models/Context/User.swift
@@ -167,7 +167,7 @@ class UserData {
             guard !state.user.isLoading else { return }
             
             Task {
-                guard let accessToken = await Rownd.getAccessToken() else {
+                guard let accessToken = try? await Rownd.getAccessToken() else {
                     return
                 }
 
@@ -212,7 +212,7 @@ class UserData {
             }
             
             Task.init {
-                guard let accessToken = await Rownd.getAccessToken() else {
+                guard let accessToken = try? await Rownd.getAccessToken() else {
                     return
                 }
 

--- a/Sources/Rownd/Rownd.swift
+++ b/Sources/Rownd/Rownd.swift
@@ -38,8 +38,9 @@ public class Rownd: NSObject {
         inst.inflateStoreCache()
         await inst.loadAppConfig()
         inst.loadAppleSignIn()
-        
-        if await Rownd.getAccessToken() != nil {
+
+
+        if ((try? await Rownd.getAccessToken() != nil) != nil) {
             DispatchQueue.main.async {
                 store.dispatch(SetUserLoading(isLoading: false)) // Make sure user is not in loading state during initial bootstrap
                 store.dispatch(UserData.fetch())
@@ -194,8 +195,8 @@ public class Rownd: NSObject {
         let _ = inst.displayHub(.manageAccount)
     }
     
-    @discardableResult public static func getAccessToken() async -> String? {
-        return await store.state.auth.getAccessToken()
+    @discardableResult public static func getAccessToken() async throws -> String? {
+        return try await store.state.auth.getAccessToken()
     }
     
     public func state() -> Store<RowndState> {
@@ -208,7 +209,7 @@ public class Rownd: NSObject {
     public static func _refreshToken() {
         Task {
             do {
-                var refreshResp = try await authenticator.refreshToken()
+                let refreshResp = try await authenticator.refreshToken()
                 print("refresh 1: \(String(describing: refreshResp))")
             } catch {
                 print("Error refreshing token 1: \(String(describing: error))")
@@ -217,7 +218,7 @@ public class Rownd: NSObject {
 
         Task {
             do {
-                var refreshResp = try await authenticator.refreshToken()
+                let refreshResp = try await authenticator.refreshToken()
                 print("refresh 2: \(String(describing: refreshResp))")
             } catch {
                 print("Error refreshing token 2: \(String(describing: error))")
@@ -226,7 +227,7 @@ public class Rownd: NSObject {
 
         Task {
             do {
-                var refreshResp = try await authenticator.refreshToken()
+                let refreshResp = try await authenticator.refreshToken()
                 print("refresh 3: \(String(describing: refreshResp))")
             } catch {
                 print("Error refreshing token 3: \(String(describing: error))")

--- a/Sources/Rownd/Rownd.swift
+++ b/Sources/Rownd/Rownd.swift
@@ -39,14 +39,6 @@ public class Rownd: NSObject {
         await inst.loadAppConfig()
         inst.loadAppleSignIn()
 
-
-        if ((try? await Rownd.getAccessToken() != nil) != nil) {
-            DispatchQueue.main.async {
-                store.dispatch(SetUserLoading(isLoading: false)) // Make sure user is not in loading state during initial bootstrap
-                store.dispatch(UserData.fetch())
-            }
-        }
-
         if !store.state.auth.isAuthenticated {
             var launchUrl: URL?
             if let _launchUrl = launchOptions?[.url] as? URL {
@@ -177,11 +169,9 @@ public class Rownd: NSObject {
     }
     
     public static func signOut() {
-        let _ = inst.displayHub(.signOut)
-
         DispatchQueue.main.async {
             store.dispatch(SetAuthState(payload: AuthState()))
-            store.dispatch(SetUserState(payload: UserState()))
+            store.dispatch(SetUserData(payload: [:]))
         }
     }
 

--- a/Sources/Rownd/Views/HubViewController.swift
+++ b/Sources/Rownd/Views/HubViewController.swift
@@ -58,7 +58,7 @@ public class HubViewController: UIViewController, HubViewProtocol, BottomSheetHo
             .data(using: .utf8)?
             .base64EncodedString(options: Data.Base64EncodingOptions(rawValue: 0)) ?? ""
 
-        var hubLoaderUrl = URLComponents(string: "\(Rownd.config.baseUrl)/mobile_app?config=\(base64EncodedConfig)")
+        let hubLoaderUrl = URLComponents(string: "\(Rownd.config.baseUrl)/mobile_app?config=\(base64EncodedConfig)")
 
         view = UIView()
         view.backgroundColor = Rownd.config.customizations.sheetBackgroundColor
@@ -68,7 +68,7 @@ public class HubViewController: UIViewController, HubViewProtocol, BottomSheetHo
         if store.state.auth.isAuthenticated {
             Task { [hubLoaderUrl] in
                 var hubLoaderUrl = hubLoaderUrl // Capture local copy of var to prevent compiler mutation issues
-                await Rownd.getAccessToken()
+                let _ = try? await Rownd.getAccessToken()
                 let rphInit = store.state.auth.toRphInitHash()
                 if let rphInit = rphInit {
                     hubLoaderUrl?.fragment = "rph_init=\(rphInit)"

--- a/Sources/Rownd/framework/Authenticator.swift
+++ b/Sources/Rownd/framework/Authenticator.swift
@@ -151,10 +151,7 @@ actor Authenticator {
                 }
 
                 // Sign the user out b/c they need to get a new refresh token - this really should be abstracted out elsewhere
-                DispatchQueue.main.async {
-                    store.dispatch(SetAuthState(payload: AuthState()))
-                    store.dispatch(SetUserData(payload: [:]))
-                }
+                Rownd.signOut()
 
                 throw AuthenticationError.refreshTokenAlreadyConsumed
             }

--- a/Sources/Rownd/framework/Container.swift
+++ b/Sources/Rownd/framework/Container.swift
@@ -1,0 +1,14 @@
+//
+//  DepContainer.swift
+//  RowndTests
+//
+//  Created by Matt Hamann on 11/10/22.
+//
+
+import Foundation
+import Factory
+import Get
+
+extension Container {
+    static let tokenApi = Factory<APIClient> { tokenApiFactory() }
+}

--- a/Sources/Rownd/framework/Container.swift
+++ b/Sources/Rownd/framework/Container.swift
@@ -1,5 +1,5 @@
 //
-//  DepContainer.swift
+//  Container.swift
 //  RowndTests
 //
 //  Created by Matt Hamann on 11/10/22.

--- a/Sources/Rownd/framework/RowndApi.swift
+++ b/Sources/Rownd/framework/RowndApi.swift
@@ -34,11 +34,15 @@ class RowndApiClientDelegate : APIClientDelegate {
         request.setValue(DEFAULT_API_USER_AGENT, forHTTPHeaderField: "User-Agent")
         request.setValue(Rownd.config.appKey, forHTTPHeaderField: "X-Rownd-App-Key")
 
-        if store.state.auth.isAuthenticated, let accessToken = await Rownd.getAccessToken() {
-            request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        do {
+            if store.state.auth.isAuthenticated, let accessToken = try await Rownd.getAccessToken() {
+                request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+            }
+        } catch {
+            // no-op
         }
 
-        var localRequest = request
+        let localRequest = request
         logger.debug("Making request to: \(String(describing: localRequest.httpMethod?.uppercased())) \(String(describing: localRequest.url))")
     }
 }


### PR DESCRIPTION
Previously, users could be inadvertently signed-out during times of poor network conditions, disruptions, service downtime, etc even when their refresh token was still perfectly valid.

Now, we take a more nuanced approach such that transient network disruptions or unexpected HTTP status codes won't immediately result in a user being signed-out. Only an HTTP status code of 400 will do that. If the condition persists after several retries, we'll throw an error to the caller so they can take any action they deem appropriate (e.g., show an error to the user, show stale data, cache the action for later, etc).