### PR TITLE
Added DispatchQueue to dispatched thunk

### DIFF
--- a/Sources/Rownd/Models/AppleSignUpCoordinator.swift
+++ b/Sources/Rownd/Models/AppleSignUpCoordinator.swift
@@ -116,7 +116,9 @@ class AppleSignUpCoordinator: NSObject, ASAuthorizationControllerDelegate, ASAut
                             }
                             
                             if (!userData.isEmpty) {
-                                dispatch(UserData.save(userData))
+                                DispatchQueue.main.async {
+                                    dispatch(UserData.save(userData))
+                                }
                             }
                         })
                     }


### PR DESCRIPTION
This is required for `UserData.save()` in order to have access to most updated Auth State