### PR TITLE
feat: recieved message from hub to disable webview loading

### DIFF
--- a/RowndFramework.xcodeproj/xcuserdata/mhamann.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/RowndFramework.xcodeproj/xcuserdata/mhamann.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>Rownd.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>22</integer>
 		</dict>
 		<key>RowndFrameworkTestApp.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>23</integer>
 		</dict>
 		<key>RowndTests.xcscheme_^#shared#^_</key>
 		<dict>

--- a/Sources/Rownd/Models/RowndHubInteropMessage.swift
+++ b/Sources/Rownd/Models/RowndHubInteropMessage.swift
@@ -50,6 +50,7 @@ enum MessageType: String, Codable {
     case triggerSignUpWithPasskey = "trigger_sign_up_with_passkey"
     case userDataUpdate = "user_data_update"
     case tryAgain = "try_again"
+    case hubLoaded = "hub_loaded"
     case unknown
 
     enum CodingKeys: String, CodingKey {
@@ -76,6 +77,7 @@ enum MessagePayload: Decodable {
     case triggerSignInWithApple(TriggerSignInWithAppleMessage)
     case triggerSignInWithGoogle(TriggerSignInWithGoogleMessage)
     case triggerSignUpWithPasskey
+    case hubLoaded
     case tryAgain
     
     enum CodingKeys: String, CodingKey {
@@ -120,6 +122,9 @@ enum MessagePayload: Decodable {
         
         case .tryAgain:
             self = .tryAgain
+            
+        case .hubLoaded:
+            self = .hubLoaded
             
         case .unknown:
             self = .unknown

--- a/Sources/Rownd/Views/HubWebView/HubWebViewController.swift
+++ b/Sources/Rownd/Views/HubWebView/HubWebViewController.swift
@@ -106,6 +106,7 @@ public class HubWebViewController: UIViewController, WKUIDelegate {
         webView.backgroundColor = UIColor.clear
         webView.scrollView.backgroundColor = UIColor.clear
         webView.hack_removeInputAccessory()
+        webView.alpha = 0
         self.modalPresentationStyle = .pageSheet
         view = webView
     }
@@ -285,12 +286,19 @@ extension HubWebViewController: WKScriptMessageHandler, WKNavigationDelegate {
             case .tryAgain:
                 startLoading()
             case .hubLoaded:
-                hubViewController?.setLoading(false)
+                self.animateInContent()
             case .unknown:
                 break
             }
         } catch {
             logger.error("Failed to decode incoming interop message: \(String(describing: error))")
+        }
+    }
+    
+    private func animateInContent() {
+        UIView.animate(withDuration: 1.0) {
+            self.webView.alpha = 1.0
+            self.hubViewController?.setLoading(false)
         }
     }
 }

--- a/Sources/Rownd/Views/HubWebView/HubWebViewController.swift
+++ b/Sources/Rownd/Views/HubWebView/HubWebViewController.swift
@@ -173,7 +173,11 @@ extension HubWebViewController: WKScriptMessageHandler, WKNavigationDelegate {
         webView.backgroundColor = UIColor.clear
         webView.scrollView.backgroundColor = UIColor.clear
         
-        hubViewController?.setLoading(false)
+        let webViewOrigin = (webView.url?.absoluteURL.scheme ?? "") + "://" + (webView.url?.absoluteURL.host ?? "")
+        if (webViewOrigin != Rownd.config.baseUrl) {
+            // Only disable loading if webView is not from hub
+            hubViewController?.setLoading(false)
+        }
         
         setFeatureFlagsJS()
         
@@ -280,6 +284,8 @@ extension HubWebViewController: WKScriptMessageHandler, WKNavigationDelegate {
                 }
             case .tryAgain:
                 startLoading()
+            case .hubLoaded:
+                hubViewController?.setLoading(false)
             case .unknown:
                 break
             }

--- a/Sources/Rownd/Views/HubWebView/HubWebViewController.swift
+++ b/Sources/Rownd/Views/HubWebView/HubWebViewController.swift
@@ -177,7 +177,7 @@ extension HubWebViewController: WKScriptMessageHandler, WKNavigationDelegate {
         let webViewOrigin = (webView.url?.absoluteURL.scheme ?? "") + "://" + (webView.url?.absoluteURL.host ?? "")
         if (webViewOrigin != Rownd.config.baseUrl) {
             // Only disable loading if webView is not from hub
-            hubViewController?.setLoading(false)
+            self.animateInContent()
         }
         
         setFeatureFlagsJS()

--- a/Sources/Rownd/Views/HubWebView/HubWebViewController.swift
+++ b/Sources/Rownd/Views/HubWebView/HubWebViewController.swift
@@ -178,8 +178,11 @@ extension HubWebViewController: WKScriptMessageHandler, WKNavigationDelegate {
         if (webViewOrigin != Rownd.config.baseUrl) {
             // Only disable loading if webView is not from hub
             self.animateInContent()
+        } else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 6.0) {
+                self.animateInContent()
+            }
         }
-        
         setFeatureFlagsJS()
         
         if let jsFnOptions = jsFnOptions {

--- a/Sources/Rownd/framework/Customizations.swift
+++ b/Sources/Rownd/framework/Customizations.swift
@@ -40,6 +40,7 @@ open class RowndCustomizations: Encodable {
             height: 100
         )
 
+        aniView.loopMode = .loop
         aniView.startAnimating()
         return aniView
     }


### PR DESCRIPTION
This should fix the Stardust loading issue when Network signal is weak: 
Bottom Sheet opens -> Loading Animation ends -> long pause -> Hub shows.

This PR is required to go out before: https://gitlab.com/rownd/privacy-hub/-/merge_requests/164?resolved_conflicts=true