### PR TITLE
fix: previous sign in method was accidentally getting reset

### DIFF
--- a/Sources/Rownd/Views/HubWebView/HubWebViewController.swift
+++ b/Sources/Rownd/Views/HubWebView/HubWebViewController.swift
@@ -232,10 +232,12 @@ extension HubWebViewController: WKScriptMessageHandler, WKNavigationDelegate {
                 guard case .authentication(let authMessage) = hubMessage.payload else { return }
                 guard hubViewController?.targetPage == .signIn  else { return }
                 DispatchQueue.main.async {
+                    if (store.state.auth.accessToken != authMessage.accessToken) {
+                        store.dispatch(ResetSignInState())
+                    }
                     store.dispatch(store.state.auth.onReceiveAuthTokens(
                         AuthState(accessToken: authMessage.accessToken, refreshToken: authMessage.refreshToken)
                     ))
-                    store.dispatch(ResetSignInState())
                 }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in // .now() + num_seconds
                     self?.hubViewController?.hide()


### PR DESCRIPTION
The Success Screen was accidentally resetting the saved previous sign in method