### PR TITLE
fix: decoding app config automations

### DIFF
--- a/Sources/Rownd/Models/Automations/AutomationEvaluators.swift
+++ b/Sources/Rownd/Models/Automations/AutomationEvaluators.swift
@@ -8,7 +8,11 @@
 import Foundation
 import AnyCodable
 
-internal func evaluateRule(userData: Dictionary<String, AnyCodable>, rule: RowndAutomationRule) -> Bool {
+internal func evaluateRule(userData: Dictionary<String, AnyCodable>?, rule: RowndAutomationRule) -> Bool {
+    guard let userData = userData else {
+        logger.error("User data not available during automation rule evaluation")
+        return false
+    }
     guard let userDataValue = userData[rule.attribute] else {
         logger.log("Attribute not found: \(rule.attribute)")
         return false

--- a/Sources/Rownd/Models/Automations/AutomationTypes.swift
+++ b/Sources/Rownd/Models/Automations/AutomationTypes.swift
@@ -14,18 +14,35 @@ public struct RowndAutomation: Hashable {
     public var template: String
     public var state: RowndAutomationState
     public var actions: [RowndAutomationAction]
-    public var rules: [RowndAutomationRule]
+    public var rules: [RowndAutomationRuleUnknown]
     public var triggers: [RowndAutomationTrigger]
+    public var platform: RowndAutomationPlatform
 }
 
 extension RowndAutomation: Codable {
     enum CodingKeys: String, CodingKey {
-        case id, name, template, state, actions, rules, triggers
+        case id, name, template, state, actions, rules, triggers, platform
     }
 }
 
-public enum RowndAutomationState: String, Codable {
-    case enabled, disabled
+public enum RowndAutomationState: String {
+    case enabled, disabled, unknown
+}
+
+extension RowndAutomationState: Codable {
+    public init(from decoder: Decoder) throws {
+        self = try RowndAutomationState(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+    }
+}
+
+public enum RowndAutomationPlatform: String {
+    case ios, android, web, unknown
+}
+
+extension RowndAutomationPlatform: Codable {
+    public init(from decoder: Decoder) throws {
+        self = try RowndAutomationPlatform(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+    }
 }
 
 public struct RowndAutomationAction: Hashable {
@@ -56,14 +73,44 @@ extension RowndAutomationActionType: Codable {
     }
 }
 
-public struct RowndAutomationRule: Hashable {
+protocol RowndAutomationRuleProto {}
+
+public enum RowndAutomationRuleUnknown: RowndAutomationRuleProto {
+    case or(RowndAutomationOrRule)
+    case rule(RowndAutomationRule)
+    case unknown
+}
+
+extension RowndAutomationRuleUnknown: Hashable, Codable {
+    enum CodingKeys: CodingKey {
+        case or, rule
+    }
+
+    public init(from decoder: Decoder) throws {
+        if let r = try? RowndAutomationOrRule(from: decoder) {
+            self = .or(r)
+        } else if let r = try? RowndAutomationRule(from: decoder) {
+            self = .rule(r)
+        } else {
+            self = .unknown
+        }
+    }
+}
+
+public struct RowndAutomationOrRule: RowndAutomationRuleProto, Hashable, Codable {
+    public var or: [RowndAutomationRuleUnknown]
+
+    enum CodingKeys: String, CodingKey {
+        case or = "$or"
+    }
+}
+
+public struct RowndAutomationRule: RowndAutomationRuleProto, Hashable, Codable {
     public var attribute: String
     public var entityType: RowndAutomationRuleEntityRule
     public var condition: RowndAutomationRuleCondition
     public var value: AnyCodable?
-}
 
-extension RowndAutomationRule: Codable {
     enum CodingKeys: String, CodingKey {
         case attribute, condition, value
         case entityType = "entity_type"

--- a/Sources/Rownd/Rownd.swift
+++ b/Sources/Rownd/Rownd.swift
@@ -29,8 +29,13 @@ public class Rownd: NSObject {
     private static var passkeyCoordinator: PasskeyCoordinator = PasskeyCoordinator()
     internal static var apiClient = RowndApi().client
     internal static var authenticator = Authenticator()
-    internal let automationsCoordinator = AutomationsCoordinator()
+    internal static let automationsCoordinator = AutomationsCoordinator()
     internal static var connectionAction = ConnectionAction()
+    
+    // Run processAutomations() every second to support time-based automations
+    internal var automationTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+        Rownd.automationsCoordinator.processAutomations()
+    }
 
     private override init() {
         super.init()

--- a/Sources/Rownd/framework/Debouncer.swift
+++ b/Sources/Rownd/framework/Debouncer.swift
@@ -8,26 +8,20 @@
 import Foundation
 
 class Debouncer {
-    private var lastFireTime = DispatchTime.now()
-    private let delay: Double
     private var workItem: DispatchWorkItem?
+    private let delay: TimeInterval
+    private let queue: DispatchQueue
 
-    init(delay: Double) {
+    init(delay: TimeInterval, queue: DispatchQueue = .main) {
         self.delay = delay
+        self.queue = queue
     }
 
-    func debounce(action: @escaping (() -> Void)) {
+    func debounce(action: @escaping () -> Void) {
         workItem?.cancel()
-        lastFireTime = DispatchTime.now()
-        workItem = DispatchWorkItem { [weak self] in
-            if let strongSelf = self,
-                DispatchTime.now() >= strongSelf.lastFireTime + strongSelf.delay {
-                action()
-            }
-        }
-        if let workItem = workItem {
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
-        }
+        let workItem = DispatchWorkItem(block: action)
+        self.workItem = workItem
+        queue.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
 }
 


### PR DESCRIPTION
Decoding of app config's was broken when an automation with an "$or" rule was present. This fixes that and adds logic to process automations with "$or" rules. Also, this includes fixes for the `Debounce` class and the way `processAutomations()` runs.