### PR TITLE
Add the SuperTokens lazy user migration flow

### DIFF
--- a/Sources/Rownd/Models/RowndConfig.swift
+++ b/Sources/Rownd/Models/RowndConfig.swift
@@ -7,6 +7,27 @@
 
 import Foundation
 
+
+public struct SuperTokensAppInfo: Encodable {
+    public var appName: String
+    public var apiDomain: String
+    public var apiBasePath: String
+
+    public init(appName: String, apiDomain: String, apiBasePath: String = "/auth") {
+        self.appName = appName
+        self.apiDomain = apiDomain
+        self.apiBasePath = apiBasePath
+    }
+}
+
+public struct SuperTokensConfig: Encodable {
+    public var appInfo: SuperTokensAppInfo
+
+    public init(appInfo: SuperTokensAppInfo) {
+        self.appInfo = appInfo
+    }
+}
+
 public struct RowndConfig: Encodable {
     internal init() {}
 
@@ -21,6 +42,7 @@ public struct RowndConfig: Encodable {
     public var customizations: RowndCustomizations = RowndCustomizations()
 
     // These will not be encoded
+    public var supertokens: SuperTokensConfig? = nil
     public var appGroupPrefix: String?
     public var enableSmartLinkPasteBehavior: Bool = true
     public var signInLinkPattern: String = ".*\\.rownd\\.link$"

--- a/Sources/Rownd/Models/RowndConfig.swift
+++ b/Sources/Rownd/Models/RowndConfig.swift
@@ -13,6 +13,43 @@ public struct SuperTokensAppInfo: Encodable {
     public var apiDomain: String
     public var apiBasePath: String
 
+    internal var normalizedApiDomain: String? {
+        let domain = apiDomain.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+        guard let url = URL(string: domain),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              url.host != nil
+        else {
+            return nil
+        }
+
+        return url.absoluteString.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    }
+
+    internal var normalizedApiBasePath: String {
+        let segments = apiBasePath
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: "/")
+            .map(String.init)
+
+        return segments.isEmpty ? "" : "/" + segments.joined(separator: "/")
+    }
+
+    internal var migrationURL: URL? {
+        guard let normalizedApiDomain else {
+            return nil
+        }
+
+        guard var components = URLComponents(string: normalizedApiDomain) else {
+            return nil
+        }
+
+        components.path = normalizedApiBasePath + "/plugin/rownd/migrate"
+        return components.url
+    }
+
     public init(appName: String, apiDomain: String, apiBasePath: String = "/auth") {
         self.appName = appName
         self.apiDomain = apiDomain

--- a/Sources/Rownd/Rownd.swift
+++ b/Sources/Rownd/Rownd.swift
@@ -48,6 +48,8 @@ public class Rownd: NSObject {
             config.appKey = _appKey
         }
 
+        registerSuperTokensSyncEventHandler()
+        
         let state = await inst.inflateStoreCache()
 
         // Skip the rest within app extensions

--- a/Sources/Rownd/framework/SuperTokensSync.swift
+++ b/Sources/Rownd/framework/SuperTokensSync.swift
@@ -31,10 +31,6 @@ private final class SuperTokensSyncEventHandler: RowndEventHandlerDelegate {
 private let superTokensSyncEventHandler = SuperTokensSyncEventHandler()
 
 func registerSuperTokensSyncEventHandler() {
-    guard Rownd.config.supertokens?.appInfo != nil else {
-        return
-    }
-
     let alreadyRegistered = Context.currentContext.eventListeners.contains { listener in
         listener === superTokensSyncEventHandler
     }
@@ -48,10 +44,15 @@ func syncUserToSuperTokens(
     accessToken: String,
     appInfo: SuperTokensAppInfo
 ) async {
-    let base = "\(appInfo.apiDomain)\(appInfo.apiBasePath)"
+    guard let url = appInfo.migrationURL else {
+        log.error(
+            "[Rownd->ST] invalid migration URL constructed from apiDomain=\(appInfo.apiDomain) apiBasePath=\(appInfo.apiBasePath)"
+        )
+        return
+    }
 
     do {
-        var request = URLRequest(url: URL(string: "\(base)/plugin/rownd/migrate")!)
+        var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.httpShouldHandleCookies = true

--- a/Sources/Rownd/framework/SuperTokensSync.swift
+++ b/Sources/Rownd/framework/SuperTokensSync.swift
@@ -1,0 +1,66 @@
+import Foundation
+import OSLog
+
+private let log = Logger(subsystem: "io.rownd.sdk", category: "supertokens-sync")
+
+private final class SuperTokensSyncEventHandler: RowndEventHandlerDelegate {
+    func handleRowndEvent(_ event: RowndEvent) {
+        let userType = event.data?["user_type"] ?? nil
+
+        guard event.event == .signInCompleted,
+              userType?.value as? String == "new_user",
+              let appInfo = Rownd.config.supertokens?.appInfo
+        else {
+            return
+        }
+
+        Task {
+            do {
+                guard let accessToken = try await Rownd.getAccessToken() else {
+                    return
+                }
+
+                await syncUserToSuperTokens(accessToken: accessToken, appInfo: appInfo)
+            } catch {
+                log.error("[Rownd->ST] failed to read access token for migration: \(error.localizedDescription)")
+            }
+        }
+    }
+}
+
+private let superTokensSyncEventHandler = SuperTokensSyncEventHandler()
+
+func registerSuperTokensSyncEventHandler() {
+    guard Rownd.config.supertokens?.appInfo != nil else {
+        return
+    }
+
+    let alreadyRegistered = Context.currentContext.eventListeners.contains { listener in
+        listener === superTokensSyncEventHandler
+    }
+
+    if !alreadyRegistered {
+        Context.currentContext.eventListeners.append(superTokensSyncEventHandler)
+    }
+}
+
+func syncUserToSuperTokens(
+    accessToken: String,
+    appInfo: SuperTokensAppInfo
+) async {
+    let base = "\(appInfo.apiDomain)\(appInfo.apiBasePath)"
+
+    do {
+        var request = URLRequest(url: URL(string: "\(base)/plugin/rownd/migrate")!)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.httpShouldHandleCookies = true
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            log.error("[Rownd->ST] migrate failed with status: \(http.statusCode)")
+        }
+    } catch {
+        log.error("[Rownd->ST] migrate failed (non-fatal): \(error.localizedDescription)")
+    }
+}


### PR DESCRIPTION
## Summary
Adds SuperTokens lazy user migration support to the iOS SDK.
When the SuperTokens config is included and a Rownd sign-in completes for a `new_user`, the SDK now calls the the `${apiBasePath}/plugin/rownd/migrate` endpoint.

- adds `SuperTokensAppInfo` and `SuperTokensConfig` to `RowndConfig`
- registers a SuperTokens sync event handler during `Rownd.configure(...)`
- listens for `signInCompleted` and only triggers migration for `new_user`
- sends the Rownd access token to `${apiBasePath}/plugin/rownd/migrate`

The main SDK behavior lives in:
- `Sources/Rownd/Models/RowndConfig.swift`
- `Sources/Rownd/Rownd.swift`
- `Sources/Rownd/framework/SuperTokensSync.swift`

## Summary by Sourcery

Add support for lazily migrating newly created Rownd users to SuperTokens in the iOS SDK.

New Features:
- Introduce SuperTokens configuration types on RowndConfig to enable SuperTokens integration.
- Automatically register a SuperTokens sync event handler during SDK configuration to observe authentication events.
- Trigger a SuperTokens migration request for newly signed-in users using the Rownd access token.