### PR TITLE
fix(instant): make forced conversion sheet non-dismissible

### DIFF
--- a/Sources/Rownd/Rownd.swift
+++ b/Sources/Rownd/Rownd.swift
@@ -188,7 +188,18 @@ public class Rownd: NSObject {
 
     @MainActor
     internal static func releaseForcedConversionLock() {
+        let wasLocked = inst.bottomSheetController.isUserDismissalDisabled
         inst.bottomSheetController.isUserDismissalDisabled = false
+        guard wasLocked else { return }
+        // The post-auth auto-close may have fired and been blocked while the lock was held
+        // (Hub schedules hide() 1.5s after `.authentication` but `authLevel` propagates from a
+        // separate UserData.fetch — the timer can lose the race). Retry the close now.
+        (inst.bottomSheetController.controller as? HubViewProtocol)?.hide()
+    }
+
+    @MainActor
+    internal static var _bottomSheetIsLocked: Bool {
+        inst.bottomSheetController.isUserDismissalDisabled
     }
 
     @MainActor

--- a/Sources/Rownd/Rownd.swift
+++ b/Sources/Rownd/Rownd.swift
@@ -181,6 +181,17 @@ public class Rownd: NSObject {
     }
 
     @MainActor
+    internal static func requestSignInForcedConversion(_ signInOptions: RowndSignInOptions?) {
+        inst.bottomSheetController.isUserDismissalDisabled = true
+        requestSignIn(signInOptions)
+    }
+
+    @MainActor
+    internal static func releaseForcedConversionLock() {
+        inst.bottomSheetController.isUserDismissalDisabled = false
+    }
+
+    @MainActor
     public static func connectAuthenticator(
         with: RowndConnectSignInHint, completion: (() -> Void)? = nil
     ) {

--- a/Sources/Rownd/Views/BottomSheetViewController.swift
+++ b/Sources/Rownd/Views/BottomSheetViewController.swift
@@ -27,7 +27,22 @@ class BottomSheetViewController: UIViewController {
     // When true, swipe-to-dismiss and tap-outside-to-dismiss are disabled for this presentation,
     // and the Hub's `can_touch_background_to_dismiss` message cannot re-enable them. Programmatic
     // dismissal (e.g. after a successful sign-in) is unaffected. Reset on viewDidDisappear.
-    var isUserDismissalDisabled: Bool = false
+    // The didSet applies the change to a live sheetController, so toggling the lock after
+    // presentation still takes effect (and unlock restores the Hub's most recent preference).
+    var isUserDismissalDisabled: Bool = false {
+        didSet {
+            guard isUserDismissalDisabled != oldValue, let sheetController = sheetController else { return }
+            if isUserDismissalDisabled {
+                sheetController.setCanTouchDimmingBackgroundToDismiss(false)
+            } else {
+                sheetController.setCanTouchDimmingBackgroundToDismiss(hubRequestedCanTouchToDismiss)
+            }
+        }
+    }
+
+    // Tracks the most recent Hub-requested dismissibility state so that releasing the lock
+    // restores whatever the Hub last asked for instead of unconditionally re-enabling.
+    private var hubRequestedCanTouchToDismiss: Bool = true
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -78,6 +93,7 @@ class BottomSheetViewController: UIViewController {
         super.viewDidDisappear(animated)
         self.controller = nil
         self.isUserDismissalDisabled = false
+        self.hubRequestedCanTouchToDismiss = true
     }
 
     func updateBottomSheetHeight(_ number: CGFloat) {
@@ -112,6 +128,7 @@ class BottomSheetViewController: UIViewController {
     }
 
     func canTouchDimmingBackgroundToDismiss(_ enable: Bool) {
+        hubRequestedCanTouchToDismiss = enable
         if isUserDismissalDisabled && enable {
             return
         }

--- a/Sources/Rownd/Views/BottomSheetViewController.swift
+++ b/Sources/Rownd/Views/BottomSheetViewController.swift
@@ -24,6 +24,11 @@ class BottomSheetViewController: UIViewController {
     var latestTargetHeight: CGFloat = 0.9
     var isKeyboardOpen = false
 
+    // When true, swipe-to-dismiss and tap-outside-to-dismiss are disabled for this presentation,
+    // and the Hub's `can_touch_background_to_dismiss` message cannot re-enable them. Programmatic
+    // dismissal (e.g. after a successful sign-in) is unaffected. Reset on viewDidDisappear.
+    var isUserDismissalDisabled: Bool = false
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         guard let controller = controller else {
@@ -54,6 +59,9 @@ class BottomSheetViewController: UIViewController {
 
         sheetController = presentAsBottomSheet(controller, theme: theme, behavior: behavior)
 
+        if isUserDismissalDisabled {
+            sheetController?.setCanTouchDimmingBackgroundToDismiss(false)
+        }
     }
 
     override func viewDidLoad() {
@@ -69,6 +77,7 @@ class BottomSheetViewController: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         self.controller = nil
+        self.isUserDismissalDisabled = false
     }
 
     func updateBottomSheetHeight(_ number: CGFloat) {
@@ -77,6 +86,10 @@ class BottomSheetViewController: UIViewController {
     }
 
     public func hideBottomSheet(_ completion: (() -> Void)? = nil) {
+        if isUserDismissalDisabled {
+            logger.debug("Ignoring hideBottomSheet: forced-conversion lock is active")
+            return
+        }
         sheetController?.dismiss(completion)
     }
 
@@ -99,6 +112,9 @@ class BottomSheetViewController: UIViewController {
     }
 
     func canTouchDimmingBackgroundToDismiss(_ enable: Bool) {
+        if isUserDismissalDisabled && enable {
+            return
+        }
         if let sheetController = sheetController {
             sheetController.setCanTouchDimmingBackgroundToDismiss(enable)
         }

--- a/Sources/Rownd/Views/HubViewController.swift
+++ b/Sources/Rownd/Views/HubViewController.swift
@@ -182,11 +182,16 @@ public class HubViewController: UIViewController, HubViewProtocol, BottomSheetHo
             self.dismiss(animated: true)
             return
         }
-        
+
+        if bottomSheetController.isUserDismissalDisabled {
+            logger.debug("Ignoring HubViewController.hide(): forced-conversion lock is active")
+            return
+        }
+
         if (isBottomSheetDismissing) {
             return
         }
-        
+
         isBottomSheetDismissing = true
         bottomSheetController.hideBottomSheet({
             self.dismiss(animated: true)

--- a/Sources/Rownd/framework/InstantUsers.swift
+++ b/Sources/Rownd/framework/InstantUsers.swift
@@ -11,6 +11,7 @@ import Combine
 class InstantUsers {
     private let context: Context
     private var cancellables = Set<AnyCancellable>()
+    private var hasTriggeredConversion: Bool = false
 
     init(
         context: Context
@@ -36,24 +37,26 @@ class InstantUsers {
             .removeDuplicates(
                 by: ==
             )
-            .first {
-                isAuthenticated,
-                authLevel in
-                isAuthenticated && authLevel == .instant
-            }
-            .sink {
-                isAuthenticated,
-                authLevel in
+            .sink { [weak self] isAuthenticated, authLevel in
+                guard let self = self, isAuthenticated else { return }
 
-                var signInOptions = RowndSignInOptions()
-                signInOptions.title = "Add a sign-in method"
-                signInOptions.subtitle = "To make sure you can always access your account, please add a sign-in method."
-                signInOptions.intent = .signUp
-                Rownd
-                    .requestSignIn(signInOptions)
+                if !self.hasTriggeredConversion && authLevel == .instant {
+                    self.hasTriggeredConversion = true
 
-                subscriber
-                    .unsubscribe()
+                    var signInOptions = RowndSignInOptions()
+                    signInOptions.title = "Add a sign-in method"
+                    signInOptions.subtitle = "To make sure you can always access your account, please add a sign-in method."
+                    signInOptions.intent = .signUp
+                    Rownd.requestSignInForcedConversion(signInOptions)
+                    return
+                }
+
+                // User has converted to a non-instant auth level (verified, unverified, guest).
+                // Release the lock so the Hub's post-success auto-close can proceed.
+                if self.hasTriggeredConversion && authLevel != .instant && authLevel != .unknown {
+                    Rownd.releaseForcedConversionLock()
+                    subscriber.unsubscribe()
+                }
             }.store(
                 in: &self.cancellables
             )

--- a/Tests/RowndTests/InstantUsersTests.swift
+++ b/Tests/RowndTests/InstantUsersTests.swift
@@ -24,6 +24,8 @@ class InstantUsersTests: XCTestCase {
 
     override func tearDown() {
         Rownd.config = originalConfig
+        // Reset the singleton lock so it does not leak between tests.
+        Rownd.releaseForcedConversionLock()
         super.tearDown()
     }
 
@@ -196,5 +198,126 @@ class InstantUsersTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 2.0)
 
         _ = instantUsers
+    }
+
+    /// Verifies that the forced-conversion lock is engaged on the singleton bottom
+    /// sheet when the conversion subscription fires for an instant user.
+    func testLockIsEngagedWhenConversionTriggers() async throws {
+        let store = createStore()
+        _ = Context(store)
+
+        Rownd.config.forceInstantUserConversion = true
+        XCTAssertFalse(Rownd._bottomSheetIsLocked, "Pre-condition: lock should start cleared")
+
+        let instantUsers = InstantUsers(context: Context.currentContext)
+        instantUsers.tmpForceInstantUserConversionIfRequested()
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        store.dispatch(SetAuthState(payload: AuthState(
+            accessToken: generateJwt(expires: Date(timeIntervalSinceNow: 3600).timeIntervalSince1970),
+            refreshToken: generateJwt(expires: Date(timeIntervalSinceNow: 36000).timeIntervalSince1970)
+        )))
+        store.dispatch(SetClockSync(clockSyncState: .synced))
+        store.dispatch(SetUserState(payload: UserState(
+            data: ["user_id": "test_instant_user"],
+            authLevel: .instant
+        )))
+
+        try await waitUntil(timeout: 2.0) { Rownd._bottomSheetIsLocked }
+        XCTAssertTrue(Rownd._bottomSheetIsLocked, "Lock should engage when authLevel transitions to .instant")
+
+        _ = instantUsers
+    }
+
+    /// Verifies that the lock releases once the user transitions from `.instant`
+    /// to a non-instant identifier auth level (e.g. `.verified`).
+    func testLockReleasesAfterVerifiedConversion() async throws {
+        let store = createStore()
+        _ = Context(store)
+
+        Rownd.config.forceInstantUserConversion = true
+
+        let instantUsers = InstantUsers(context: Context.currentContext)
+        instantUsers.tmpForceInstantUserConversionIfRequested()
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        store.dispatch(SetAuthState(payload: AuthState(
+            accessToken: generateJwt(expires: Date(timeIntervalSinceNow: 3600).timeIntervalSince1970),
+            refreshToken: generateJwt(expires: Date(timeIntervalSinceNow: 36000).timeIntervalSince1970)
+        )))
+        store.dispatch(SetClockSync(clockSyncState: .synced))
+        store.dispatch(SetUserState(payload: UserState(
+            data: ["user_id": "test_instant_user"],
+            authLevel: .instant
+        )))
+
+        try await waitUntil(timeout: 2.0) { Rownd._bottomSheetIsLocked }
+
+        // Simulate successful conversion: user-data fetch returns with verified level.
+        store.dispatch(SetUserState(payload: UserState(
+            data: ["user_id": "test_verified_user", "email": "user@example.com"],
+            authLevel: .verified
+        )))
+
+        try await waitUntil(timeout: 2.0) { !Rownd._bottomSheetIsLocked }
+        XCTAssertFalse(Rownd._bottomSheetIsLocked, "Lock should release once authLevel becomes .verified")
+
+        _ = instantUsers
+    }
+
+    /// Verifies that the `hasTriggeredConversion` gate prevents the conversion
+    /// flow from re-triggering after a successful conversion + lock release.
+    /// (The customer-confirmed behavior is once-per-session.)
+    func testConversionDoesNotRetriggerAfterRelease() async throws {
+        let store = createStore()
+        _ = Context(store)
+
+        Rownd.config.forceInstantUserConversion = true
+
+        let instantUsers = InstantUsers(context: Context.currentContext)
+        instantUsers.tmpForceInstantUserConversionIfRequested()
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // First .instant → lock should engage.
+        store.dispatch(SetAuthState(payload: AuthState(
+            accessToken: generateJwt(expires: Date(timeIntervalSinceNow: 3600).timeIntervalSince1970),
+            refreshToken: generateJwt(expires: Date(timeIntervalSinceNow: 36000).timeIntervalSince1970)
+        )))
+        store.dispatch(SetClockSync(clockSyncState: .synced))
+        store.dispatch(SetUserState(payload: UserState(
+            data: ["user_id": "test_instant_user"],
+            authLevel: .instant
+        )))
+        try await waitUntil(timeout: 2.0) { Rownd._bottomSheetIsLocked }
+
+        // Convert and release.
+        store.dispatch(SetUserState(payload: UserState(
+            data: ["user_id": "test_user", "email": "user@example.com"],
+            authLevel: .verified
+        )))
+        try await waitUntil(timeout: 2.0) { !Rownd._bottomSheetIsLocked }
+
+        // Drop back to .instant — should NOT re-engage the lock (once-per-session).
+        store.dispatch(SetUserState(payload: UserState(
+            data: ["user_id": "test_user"],
+            authLevel: .instant
+        )))
+        try await Task.sleep(nanoseconds: 200_000_000)
+        XCTAssertFalse(Rownd._bottomSheetIsLocked, "Conversion must not re-trigger after a successful release")
+
+        _ = instantUsers
+    }
+
+    // MARK: - helpers
+
+    private func waitUntil(timeout: TimeInterval, condition: @escaping () -> Bool) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 25_000_000)
+        }
     }
 }


### PR DESCRIPTION
## Summary

When `Rownd.config.forceInstantUserConversion` is enabled, the SDK now actually forces the sign-in sheet to stay open until the user adds an identifier. Previously the sheet defaulted to dismissible by swipe, tap-outside, and any Hub-dispatched close message — so customers with large populations of instant users would see the prompt and dismiss it without converting.

Reported impact: ~8,000 active instant users that never converted, on at least one customer.

## What changed

- **`BottomSheetViewController`** gains an `isUserDismissalDisabled` flag. When set before presentation, `viewWillAppear` calls `setCanTouchDimmingBackgroundToDismiss(false)` after the LBBottomSheet is created (disables both swipe-to-dismiss and tap-outside-to-dismiss). The flag is reset on `viewDidDisappear`. The existing `canTouchDimmingBackgroundToDismiss(_:)` now refuses re-enable calls from the Hub while the lock is active.
- **`hideBottomSheet`** and **`HubViewController.hide()`** both honor the same lock, so the Hub's `closeHubViewController` and `signOut` messages cannot close the sheet either.
- **`Rownd.requestSignInForcedConversion(_:)`** / **`Rownd.releaseForcedConversionLock()`** — internal helpers to set/clear the lock.
- **`InstantUsers`** now keeps its subscription alive past the initial trigger. When the user's `authLevel` transitions out of `.instant` (to `.verified`, `.unverified`, or `.guest`), it releases the lock so the Hub's post-success auto-close (`hide()` 1.5s after the `.authentication` message) proceeds normally. `.unknown` is treated as a transient state and does not release.

## No Hub-side change required

The fix is iOS-only. Existing customers don't need to update their Hub configuration — flipping `forceInstantUserConversion` on the iOS side is sufficient.

## Test plan

- [ ] Verify with `forceInstantUserConversion = false` (default): sheet behavior is unchanged — swipe, tap-outside, and Hub close messages all dismiss as before.
- [ ] Verify with `forceInstantUserConversion = true`:
    - [ ] Sheet appears when the user enters an authenticated `.instant` state.
    - [ ] Swipe-down does not dismiss.
    - [ ] Tap-outside does not dismiss.
    - [ ] Any Hub-side close button (`closeHubViewController` message) does not dismiss.
    - [ ] On successful sign-in (email, Apple, Google, passkey), the sheet auto-closes once `authLevel` transitions to non-`.instant`.
- [ ] Confirm the Hub's in-sheet "X" / close affordance, if rendered, is the only remaining escape (this PR cannot block Hub-internal UI — flag separately if customers need that too).
- [ ] Build the example app (`landmarks` scheme) on an iOS 18 simulator with the flag set — verified locally.

## Notes

- The Hub's web UI may still render its own close button inside the sheet; that's out of scope here. If a customer needs that hidden too, it should be addressed in the Hub.
- The lock is process-local on the singleton `BottomSheetViewController` and self-resets on `viewDidDisappear`, so it cannot leak across app launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce non-dismissible sign-in bottom sheet for instant users when forced conversion is enabled, and automatically release the lock after successful conversion.

New Features:
- Introduce a forced-conversion sign-in flow that prevents user-initiated dismissal of the bottom sheet for instant users until they add a sign-in method.

Enhancements:
- Add a dismissal lock on the shared bottom sheet controller that blocks swipe, tap-outside, and Hub-triggered closes while forced conversion is active.
- Keep the instant user subscription alive to detect auth level transitions and release the dismissal lock once the user is no longer an instant user.