### PR TITLE
[3.x backport] fix(instant): make forced conversion sheet non-dismissible

### DIFF
--- a/Sources/Rownd/Rownd.swift
+++ b/Sources/Rownd/Rownd.swift
@@ -179,6 +179,28 @@ public class Rownd: NSObject {
     }
 
     @MainActor
+    internal static func requestSignInForcedConversion(_ signInOptions: RowndSignInOptions?) {
+        inst.bottomSheetController.isUserDismissalDisabled = true
+        requestSignIn(signInOptions)
+    }
+
+    @MainActor
+    internal static func releaseForcedConversionLock() {
+        let wasLocked = inst.bottomSheetController.isUserDismissalDisabled
+        inst.bottomSheetController.isUserDismissalDisabled = false
+        guard wasLocked else { return }
+        // The post-auth auto-close may have fired and been blocked while the lock was held
+        // (Hub schedules hide() 1.5s after `.authentication` but `authLevel` propagates from a
+        // separate UserData.fetch — the timer can lose the race). Retry the close now.
+        (inst.bottomSheetController.controller as? HubViewProtocol)?.hide()
+    }
+
+    @MainActor
+    internal static var _bottomSheetIsLocked: Bool {
+        inst.bottomSheetController.isUserDismissalDisabled
+    }
+
+    @MainActor
     public static func connectAuthenticator(
         with: RowndConnectSignInHint, completion: (() -> Void)? = nil
     ) {

--- a/Sources/Rownd/Views/BottomSheetViewController.swift
+++ b/Sources/Rownd/Views/BottomSheetViewController.swift
@@ -24,6 +24,26 @@ class BottomSheetViewController: UIViewController {
     var latestTargetHeight: CGFloat = 0.9
     var isKeyboardOpen = false
 
+    // When true, swipe-to-dismiss and tap-outside-to-dismiss are disabled for this presentation,
+    // and the Hub's `can_touch_background_to_dismiss` message cannot re-enable them. Programmatic
+    // dismissal (e.g. after a successful sign-in) is unaffected. Reset on viewDidDisappear.
+    // The didSet applies the change to a live sheetController, so toggling the lock after
+    // presentation still takes effect (and unlock restores the Hub's most recent preference).
+    var isUserDismissalDisabled: Bool = false {
+        didSet {
+            guard isUserDismissalDisabled != oldValue, let sheetController = sheetController else { return }
+            if isUserDismissalDisabled {
+                sheetController.setCanTouchDimmingBackgroundToDismiss(false)
+            } else {
+                sheetController.setCanTouchDimmingBackgroundToDismiss(hubRequestedCanTouchToDismiss)
+            }
+        }
+    }
+
+    // Tracks the most recent Hub-requested dismissibility state so that releasing the lock
+    // restores whatever the Hub last asked for instead of unconditionally re-enabling.
+    private var hubRequestedCanTouchToDismiss: Bool = true
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         guard let controller = controller else {
@@ -54,6 +74,9 @@ class BottomSheetViewController: UIViewController {
 
         sheetController = presentAsBottomSheet(controller, theme: theme, behavior: behavior)
 
+        if isUserDismissalDisabled {
+            sheetController?.setCanTouchDimmingBackgroundToDismiss(false)
+        }
     }
 
     override func viewDidLoad() {
@@ -69,6 +92,8 @@ class BottomSheetViewController: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         self.controller = nil
+        self.isUserDismissalDisabled = false
+        self.hubRequestedCanTouchToDismiss = true
     }
 
     func updateBottomSheetHeight(_ number: CGFloat) {
@@ -77,6 +102,10 @@ class BottomSheetViewController: UIViewController {
     }
 
     public func hideBottomSheet(_ completion: (() -> Void)? = nil) {
+        if isUserDismissalDisabled {
+            logger.debug("Ignoring hideBottomSheet: forced-conversion lock is active")
+            return
+        }
         sheetController?.dismiss(completion)
     }
 
@@ -99,6 +128,10 @@ class BottomSheetViewController: UIViewController {
     }
 
     func canTouchDimmingBackgroundToDismiss(_ enable: Bool) {
+        hubRequestedCanTouchToDismiss = enable
+        if isUserDismissalDisabled && enable {
+            return
+        }
         if let sheetController = sheetController {
             sheetController.setCanTouchDimmingBackgroundToDismiss(enable)
         }

--- a/Sources/Rownd/Views/HubViewController.swift
+++ b/Sources/Rownd/Views/HubViewController.swift
@@ -182,11 +182,16 @@ public class HubViewController: UIViewController, HubViewProtocol, BottomSheetHo
             self.dismiss(animated: true)
             return
         }
-        
+
+        if bottomSheetController.isUserDismissalDisabled {
+            logger.debug("Ignoring HubViewController.hide(): forced-conversion lock is active")
+            return
+        }
+
         if (isBottomSheetDismissing) {
             return
         }
-        
+
         isBottomSheetDismissing = true
         bottomSheetController.hideBottomSheet({
             self.dismiss(animated: true)

--- a/Sources/Rownd/framework/InstantUsers.swift
+++ b/Sources/Rownd/framework/InstantUsers.swift
@@ -11,6 +11,7 @@ import Combine
 class InstantUsers {
     private let context: Context
     private var cancellables = Set<AnyCancellable>()
+    private var hasTriggeredConversion: Bool = false
 
     init(
         context: Context
@@ -36,24 +37,26 @@ class InstantUsers {
             .removeDuplicates(
                 by: ==
             )
-            .first {
-                isAuthenticated,
-                authLevel in
-                isAuthenticated && authLevel == .instant
-            }
-            .sink {
-                isAuthenticated,
-                authLevel in
+            .sink { [weak self] isAuthenticated, authLevel in
+                guard let self = self, isAuthenticated else { return }
 
-                var signInOptions = RowndSignInOptions()
-                signInOptions.title = "Add a sign-in method"
-                signInOptions.subtitle = "To make sure you can always access your account, please add a sign-in method."
-                signInOptions.intent = .signUp
-                Rownd
-                    .requestSignIn(signInOptions)
+                if !self.hasTriggeredConversion && authLevel == .instant {
+                    self.hasTriggeredConversion = true
 
-                subscriber
-                    .unsubscribe()
+                    var signInOptions = RowndSignInOptions()
+                    signInOptions.title = "Add a sign-in method"
+                    signInOptions.subtitle = "To make sure you can always access your account, please add a sign-in method."
+                    signInOptions.intent = .signUp
+                    Rownd.requestSignInForcedConversion(signInOptions)
+                    return
+                }
+
+                // User has converted to a non-instant auth level (verified, unverified, guest).
+                // Release the lock so the Hub's post-success auto-close can proceed.
+                if self.hasTriggeredConversion && authLevel != .instant && authLevel != .unknown {
+                    Rownd.releaseForcedConversionLock()
+                    subscriber.unsubscribe()
+                }
             }.store(
                 in: &self.cancellables
             )

--- a/Tests/RowndTests/InstantUsersTests.swift
+++ b/Tests/RowndTests/InstantUsersTests.swift
@@ -24,6 +24,8 @@ class InstantUsersTests: XCTestCase {
 
     override func tearDown() {
         Rownd.config = originalConfig
+        // Reset the singleton lock so it does not leak between tests.
+        Rownd.releaseForcedConversionLock()
         super.tearDown()
     }
 
@@ -196,5 +198,126 @@ class InstantUsersTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 2.0)
 
         _ = instantUsers
+    }
+
+    /// Verifies that the forced-conversion lock is engaged on the singleton bottom
+    /// sheet when the conversion subscription fires for an instant user.
+    func testLockIsEngagedWhenConversionTriggers() async throws {
+        let store = createStore()
+        _ = Context(store)
+
+        Rownd.config.forceInstantUserConversion = true
+        XCTAssertFalse(Rownd._bottomSheetIsLocked, "Pre-condition: lock should start cleared")
+
+        let instantUsers = InstantUsers(context: Context.currentContext)
+        instantUsers.tmpForceInstantUserConversionIfRequested()
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        store.dispatch(SetAuthState(payload: AuthState(
+            accessToken: generateJwt(expires: Date(timeIntervalSinceNow: 3600).timeIntervalSince1970),
+            refreshToken: generateJwt(expires: Date(timeIntervalSinceNow: 36000).timeIntervalSince1970)
+        )))
+        store.dispatch(SetClockSync(clockSyncState: .synced))
+        store.dispatch(SetUserState(payload: UserState(
+            data: ["user_id": "test_instant_user"],
+            authLevel: .instant
+        )))
+
+        try await waitUntil(timeout: 2.0) { Rownd._bottomSheetIsLocked }
+        XCTAssertTrue(Rownd._bottomSheetIsLocked, "Lock should engage when authLevel transitions to .instant")
+
+        _ = instantUsers
+    }
+
+    /// Verifies that the lock releases once the user transitions from `.instant`
+    /// to a non-instant identifier auth level (e.g. `.verified`).
+    func testLockReleasesAfterVerifiedConversion() async throws {
+        let store = createStore()
+        _ = Context(store)
+
+        Rownd.config.forceInstantUserConversion = true
+
+        let instantUsers = InstantUsers(context: Context.currentContext)
+        instantUsers.tmpForceInstantUserConversionIfRequested()
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        store.dispatch(SetAuthState(payload: AuthState(
+            accessToken: generateJwt(expires: Date(timeIntervalSinceNow: 3600).timeIntervalSince1970),
+            refreshToken: generateJwt(expires: Date(timeIntervalSinceNow: 36000).timeIntervalSince1970)
+        )))
+        store.dispatch(SetClockSync(clockSyncState: .synced))
+        store.dispatch(SetUserState(payload: UserState(
+            data: ["user_id": "test_instant_user"],
+            authLevel: .instant
+        )))
+
+        try await waitUntil(timeout: 2.0) { Rownd._bottomSheetIsLocked }
+
+        // Simulate successful conversion: user-data fetch returns with verified level.
+        store.dispatch(SetUserState(payload: UserState(
+            data: ["user_id": "test_verified_user", "email": "user@example.com"],
+            authLevel: .verified
+        )))
+
+        try await waitUntil(timeout: 2.0) { !Rownd._bottomSheetIsLocked }
+        XCTAssertFalse(Rownd._bottomSheetIsLocked, "Lock should release once authLevel becomes .verified")
+
+        _ = instantUsers
+    }
+
+    /// Verifies that the `hasTriggeredConversion` gate prevents the conversion
+    /// flow from re-triggering after a successful conversion + lock release.
+    /// (The customer-confirmed behavior is once-per-session.)
+    func testConversionDoesNotRetriggerAfterRelease() async throws {
+        let store = createStore()
+        _ = Context(store)
+
+        Rownd.config.forceInstantUserConversion = true
+
+        let instantUsers = InstantUsers(context: Context.currentContext)
+        instantUsers.tmpForceInstantUserConversionIfRequested()
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // First .instant → lock should engage.
+        store.dispatch(SetAuthState(payload: AuthState(
+            accessToken: generateJwt(expires: Date(timeIntervalSinceNow: 3600).timeIntervalSince1970),
+            refreshToken: generateJwt(expires: Date(timeIntervalSinceNow: 36000).timeIntervalSince1970)
+        )))
+        store.dispatch(SetClockSync(clockSyncState: .synced))
+        store.dispatch(SetUserState(payload: UserState(
+            data: ["user_id": "test_instant_user"],
+            authLevel: .instant
+        )))
+        try await waitUntil(timeout: 2.0) { Rownd._bottomSheetIsLocked }
+
+        // Convert and release.
+        store.dispatch(SetUserState(payload: UserState(
+            data: ["user_id": "test_user", "email": "user@example.com"],
+            authLevel: .verified
+        )))
+        try await waitUntil(timeout: 2.0) { !Rownd._bottomSheetIsLocked }
+
+        // Drop back to .instant — should NOT re-engage the lock (once-per-session).
+        store.dispatch(SetUserState(payload: UserState(
+            data: ["user_id": "test_user"],
+            authLevel: .instant
+        )))
+        try await Task.sleep(nanoseconds: 200_000_000)
+        XCTAssertFalse(Rownd._bottomSheetIsLocked, "Conversion must not re-trigger after a successful release")
+
+        _ = instantUsers
+    }
+
+    // MARK: - helpers
+
+    private func waitUntil(timeout: TimeInterval, condition: @escaping () -> Bool) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 25_000_000)
+        }
     }
 }


### PR DESCRIPTION
Backports #125 to the v3.x maintenance line.

Cherry-picked from `8731aac` (the squash-merge of #125 into `main`) onto a new `release/3.x` branch cut from tag `3.14.10`. The cherry-pick auto-merged a single context overlap in `Rownd.swift` (added `registerSuperTokensSyncEventHandler()` call from #124 isn't present here, since #124 is the v4 breaking change we're deliberately leaving out).

## Summary

When `Rownd.config.forceInstantUserConversion` is enabled, the sign-in sheet now:
- Cannot be swiped down to dismiss.
- Cannot be dismissed by tapping outside.
- Ignores Hub-dispatched `closeHubViewController` / `signOut` messages.
- Auto-closes after the user successfully adds an identifier (`authLevel` transitions out of `.instant`), including a retry of the post-auth `hide()` to handle the race between the Hub's 1.5s timer and `UserData.fetch` propagating `authLevel`.

No Hub-side changes required.

## Test plan

- [x] `RowndTests/InstantUsersTests` — all 7 tests pass (4 existing + 3 new for this fix).
- [x] SDK builds clean against `generic/platform=iOS Simulator`.
- [ ] Smoke test on simulator with `forceInstantUserConversion = true` in the example AppDelegate.

## Release path

This PR targets `release/3.x` (newly created from `3.14.10`). Merge → run the project's release tooling against `release/3.x` to cut e.g. `3.14.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce a non-dismissible sign-in sheet for forced instant user conversion and ensure it auto-closes once conversion completes.

Bug Fixes:
- Prevent the instant-user forced conversion sheet from being dismissed via gestures, background taps, or Hub-driven hide calls while conversion is required.
- Ensure the forced conversion sheet reliably auto-closes after the user transitions from an instant to a non-instant auth level, even when Hub timers and auth propagation race.

Enhancements:
- Track and gate the instant-user conversion flow so it triggers at most once per session and releases the lock when conversion completes.

Tests:
- Add instant-user tests covering lock engagement, release after verified conversion, and once-per-session behavior, including a helper to wait on lock state across async updates.